### PR TITLE
Closes #105 New Badges Page

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -47,6 +47,16 @@ service cloud.firestore {
       allow update, delete: if false;
     }
 
+    match /badges/{id} {
+      allow read: if true;
+      allow write: if isAdmin();
+    }
+
+    match /playerBadges/{id} {
+      allow read: if isSignedIn();
+      allow write: if isTeamLead(incomingData().teamId) || isAdmin();
+    }
+
     /// Utility Functions ///
 
     // Current DB record of document being requested

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -10,6 +10,7 @@ import { HomePageComponent } from './ui/home-page/home-page.component';
 import { UploadPageComponent } from './uploads/upload-page/upload-page.component';
 import { JoinTeamPageComponent } from './ui/join-team-page/join-team-page.component';
 import { TeamPageComponent } from './ui/team-page/team-page.component';
+import { MyBadgesComponent } from './badges/my-badges/my-badges.component';
 
 
 const routes: Routes = [
@@ -20,6 +21,7 @@ const routes: Routes = [
   { path: 'admin', component: AdminPageComponent, canActivate: [AuthGuard] },
   { path: 'register', component: JoinTeamPageComponent, canActivate: [AuthGuard] },
   { path: 'team', component: TeamPageComponent, canActivate: [AuthGuard] },
+  { path: 'badges', component: MyBadgesComponent, canActivate: [AuthGuard] },
 ];
 
 @NgModule({

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -55,6 +55,12 @@
             <mat-icon class="icon">group</mat-icon>
             <span>Team</span>
           </a>
+          <a mat-list-item
+            [routerLinkActive]="['active-menu']"
+            routerLink="/badges"
+            (click)="closeSideNav()">
+            <mat-icon class="icon">stars</mat-icon>Badges
+          </a>
           <a mat-list-item *ngIf="user.isAdmin"
             [routerLinkActive]="['active-menu']"
             routerLink="/admin"

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -20,15 +20,17 @@ import { AngularFireStorageModule } from '@angular/fire/storage';
 import { AngularFireAuthModule } from '@angular/fire/auth';
 import { AngularFireFunctionsModule, FunctionsRegionToken } from '@angular/fire/functions';
 
-import { AppRoutingModule } from './app-routing.module';
-import { AppComponent } from './app.component';
 import { environment } from '../environments/environment';
+import { AppComponent } from './app.component';
+import { CacheReuseStrategy } from './core/cache-reuse-strategy';
+// Internal modules
+import { AppRoutingModule } from './app-routing.module';
+import { BadgesModule } from './badges/badges.module';
 import { CoreModule } from './core/core.module';
-import { UploadsModule } from './uploads/uploads.module';
-import { UiModule } from './ui/ui.module';
 import { NotesModule } from './notes/notes.module';
 import { TeamsModule } from './teams/teams.module';
-import { CacheReuseStrategy } from './core/cache-reuse-strategy';
+import { UiModule } from './ui/ui.module';
+import { UploadsModule } from './uploads/uploads.module';
 
 
 @NgModule({
@@ -40,6 +42,7 @@ import { CacheReuseStrategy } from './core/cache-reuse-strategy';
     AngularFireStorageModule,
     AngularFireFunctionsModule,
     AppRoutingModule,
+    BadgesModule,
     BrowserAnimationsModule,
     BrowserModule.withServerTransition({ appId: 'serverApp' }),
     BrowserTransferStateModule,

--- a/src/app/badges/badge.d.ts
+++ b/src/app/badges/badge.d.ts
@@ -1,0 +1,15 @@
+interface Badge {
+  id?: string;
+  url: string;
+  name: string;
+  description: string;
+}
+
+interface PlayerBadge {
+  id?: string;
+  badge: Badge;
+  playerId: string;
+  teamId: string;
+  seasonId: string;
+  awardedDate: firebase.firestore.Timestamp;
+}

--- a/src/app/badges/badge/badge-image.component.html
+++ b/src/app/badges/badge/badge-image.component.html
@@ -1,0 +1,1 @@
+<img src="{{badge.url}}"/>{{badge.name}}

--- a/src/app/badges/badge/badge-image.component.scss
+++ b/src/app/badges/badge/badge-image.component.scss
@@ -1,0 +1,11 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-weight: bold;
+}
+
+img {
+  height: 100px;
+  width: 100px;
+}

--- a/src/app/badges/badge/badge-image.component.spec.ts
+++ b/src/app/badges/badge/badge-image.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { BadgeImageComponent } from './badge-image.component';
+
+describe('BadgeImageComponent', () => {
+  let component: BadgeImageComponent;
+  let fixture: ComponentFixture<BadgeImageComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ BadgeImageComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(BadgeImageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/badges/badge/badge-image.component.ts
+++ b/src/app/badges/badge/badge-image.component.ts
@@ -1,0 +1,12 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'badge-image',
+  templateUrl: './badge-image.component.html',
+  styleUrls: ['./badge-image.component.scss']
+})
+export class BadgeImageComponent {
+
+  @Input() badge: Badge;
+
+}

--- a/src/app/badges/badges.module.ts
+++ b/src/app/badges/badges.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MyBadgesComponent } from './my-badges/my-badges.component';
+import { BadgeImageComponent } from './badge/badge-image.component';
+
+@NgModule({
+  declarations: [
+    MyBadgesComponent,
+    BadgeImageComponent
+  ],
+  imports: [
+    CommonModule
+  ]
+})
+export class BadgesModule { }

--- a/src/app/badges/badges.service.spec.ts
+++ b/src/app/badges/badges.service.spec.ts
@@ -1,0 +1,12 @@
+import { TestBed } from '@angular/core/testing';
+
+import { BadgesService } from './badges.service';
+
+describe('BadgesService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: BadgesService = TestBed.get(BadgesService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/badges/badges.service.ts
+++ b/src/app/badges/badges.service.ts
@@ -17,7 +17,7 @@ export class BadgesService {
     this.playerBadges = this.afs.collection('playerBadges');
   }
 
-  getMyBadges(uid: string): Observable<PlayerBadge[]> {
+  getUserBadges(uid: string): Observable<PlayerBadge[]> {
     const badges = this.afs.collection<PlayerBadge>('playerBadges', ref =>
       ref.where('playerId', '==', uid));
 

--- a/src/app/badges/badges.service.ts
+++ b/src/app/badges/badges.service.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@angular/core';
+import { AngularFirestore, AngularFirestoreCollection } from '@angular/fire/firestore';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { firestore } from 'firebase/app';
+
+const Timestamp = firestore.Timestamp;
+
+@Injectable({
+  providedIn: 'root'
+})
+export class BadgesService {
+
+  playerBadges: AngularFirestoreCollection<PlayerBadge>;
+
+  constructor(private afs: AngularFirestore) {
+    this.playerBadges = this.afs.collection('playerBadges');
+  }
+
+  getMyBadges(uid: string): Observable<PlayerBadge[]> {
+    const badges = this.afs.collection<PlayerBadge>('playerBadges', ref =>
+      ref.where('playerId', '==', uid));
+
+    return badges.valueChanges();
+  }
+
+  async awardBadge(playerId: string, teamId: string, seasonId: string, badge: Badge) {
+    const awardedDate = Timestamp.now();
+    const playerBadgeDoc = await this.playerBadges.add({
+      badge,
+      playerId,
+      teamId,
+      seasonId,
+      awardedDate
+    });
+
+    return playerBadgeDoc.id;
+  }
+}

--- a/src/app/badges/my-badges/my-badges.component.html
+++ b/src/app/badges/my-badges/my-badges.component.html
@@ -1,0 +1,4 @@
+<h3>Earned Badges:</h3>
+<div class="badge-container">
+  <badge-image [badge]="myBadge.badge" *ngFor="let myBadge of myBadges$ | async"></badge-image>
+</div>

--- a/src/app/badges/my-badges/my-badges.component.scss
+++ b/src/app/badges/my-badges/my-badges.component.scss
@@ -1,0 +1,9 @@
+:host {
+  display: block;
+  margin: 10px 10px 50px;
+}
+
+.badge-container {
+  display: flex;
+  flex-wrap: wrap;
+}

--- a/src/app/badges/my-badges/my-badges.component.spec.ts
+++ b/src/app/badges/my-badges/my-badges.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MyBadgesComponent } from './my-badges.component';
+
+describe('MyBadgesComponent', () => {
+  let component: MyBadgesComponent;
+  let fixture: ComponentFixture<MyBadgesComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ MyBadgesComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MyBadgesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/badges/my-badges/my-badges.component.ts
+++ b/src/app/badges/my-badges/my-badges.component.ts
@@ -20,6 +20,6 @@ export class MyBadgesComponent implements OnInit {
 
   ngOnInit() {
     const user = this.auth.user$.value;
-    this.myBadges$ = this.badges.getMyBadges(user.uid);
+    this.myBadges$ = this.badges.getUserBadges(user.uid);
   }
 }

--- a/src/app/badges/my-badges/my-badges.component.ts
+++ b/src/app/badges/my-badges/my-badges.component.ts
@@ -1,0 +1,25 @@
+import { Component, OnInit } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { AuthService } from 'src/app/core/auth.service';
+import { BadgesService } from '../badges.service';
+
+@Component({
+  selector: 'my-badges',
+  templateUrl: './my-badges.component.html',
+  styleUrls: ['./my-badges.component.scss']
+})
+export class MyBadgesComponent implements OnInit {
+
+  myBadges$: Observable<PlayerBadge[]>;
+
+  constructor(
+    private auth: AuthService,
+    private badges: BadgesService
+  ) {}
+
+  ngOnInit() {
+    const user = this.auth.user$.value;
+    this.myBadges$ = this.badges.getMyBadges(user.uid);
+  }
+}


### PR DESCRIPTION
This includes a new module for badges and a new service for badges which can get/assign player badges. Includes firestore security rules to restrict player badge creation for admin and team leads only.

New Badges page:
![image](https://user-images.githubusercontent.com/11013464/62675863-464df000-b9db-11e9-8f3b-2f1b09bb1d45.png)
