### PR TITLE
admin function to add memberships

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -11,7 +11,7 @@ service cloud.firestore {
     }
 
     match /users/{userId} {
-      allow read, write: if isOwner(userId);
+      allow read, write: if isAdmin() || isOwner(userId);
     }
 
     match /questCategories/{id} {
@@ -32,8 +32,8 @@ service cloud.firestore {
 
     match /membership/{id} {
       allow read: if true;
-      allow create: if isOwner(incomingData().uid) && incomingData().isApproved == false;
-      allow update, delete: if isTeamLead(existingData().teamId);
+      allow create: if isAdmin() || isOwner(incomingData().uid) && incomingData().isApproved == false;
+      allow update, delete: if isAdmin() || isTeamLead(existingData().teamId);
     }
 
     match /teams/{id} {
@@ -142,8 +142,7 @@ service cloud.firestore {
     }
 
     function isAdmin() {
-      return getAdminData(currentUser().uid).uid == currentUser().uid &&
-        incomingData().updated_by.uid == currentUser().uid;
+      return getAdminData(currentUser().uid).uid == currentUser().uid;
     }
   }
 }

--- a/src/app/core/user.service.ts
+++ b/src/app/core/user.service.ts
@@ -1,9 +1,7 @@
 import { Injectable } from '@angular/core';
-
-import {
-  AngularFirestore
-} from '@angular/fire/firestore';
+import { AngularFirestore } from '@angular/fire/firestore';
 import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 @Injectable({
   providedIn: 'root'
@@ -13,10 +11,15 @@ export class UserService {
 
   /**
    * Get user info from given id
-   * @param  {string}                                id user id
+   * @param  {string}                              id user id
    * @return {Observable<User>}    observable user info
    */
   getUser(uid: string): Observable<User> {
     return this.afs.doc<User>(`users/${uid}`).valueChanges();
+  }
+
+  getUserFromEmail(email: string): Observable<User> {
+    return this.afs.collection<User>('users', ref => ref.where('email', '==', email))
+      .valueChanges().pipe(map(users => users.length ? users[0] : null));
   }
 }

--- a/src/app/ui/admin-page/admin-page.component.html
+++ b/src/app/ui/admin-page/admin-page.component.html
@@ -55,4 +55,30 @@
     <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
     <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
   </table>
+
+  <hr/>
+
+  <mat-toolbar class="quest-toolbar" color="primary">Teams</mat-toolbar>
+  <table mat-table [dataSource]="teams$ | async">
+    <ng-container matColumnDef="name">
+      <th mat-header-cell *matHeaderCellDef> Team Name </th>
+      <td mat-cell *matCellDef="let team" class="team"> {{team.name}} </td>
+    </ng-container>
+
+    <ng-container matColumnDef="action">
+      <th mat-header-cell *matHeaderCellDef></th>
+      <td mat-cell *matCellDef="let team" class="team">
+        <div class="member">
+          <input matInput placeholder="Email of user to be added" [(ngModel)]="team.email" />
+          <mat-checkbox [(ngModel)]="team.isLead">isLead</mat-checkbox>
+          <button mat-stroked-button color="primary" (click)="addMembership(team, team.email, team.isLead)">
+            Add to Team
+          </button>
+        </div>
+      </td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="teamColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: teamColumns;"></tr>
+  </table>
 </div>

--- a/src/app/ui/admin-page/admin-page.component.scss
+++ b/src/app/ui/admin-page/admin-page.component.scss
@@ -18,3 +18,16 @@ form {
 .season {
   color: mat-color(mat-palette($mat-indigo));
 }
+
+.member {
+  display: flex;
+  align-items: center;
+
+  > * {
+    flex: 1 1 auto;
+  }
+
+  mat-checkbox {
+    margin: 0 10px;
+  }
+}

--- a/src/app/ui/admin-page/admin-page.component.ts
+++ b/src/app/ui/admin-page/admin-page.component.ts
@@ -1,12 +1,14 @@
 import { Component, OnInit } from '@angular/core';
 import { FormControl, Validators } from '@angular/forms';
-import { Observable } from 'rxjs';
-
-import { AuthService } from '../../core/auth.service';
-import { SeasonService } from '../../core/season.service';
 import { MatDialog } from '@angular/material';
+import { Observable } from 'rxjs';
+import { filter } from 'rxjs/operators';
+
 import { AddSeasonDialogComponent } from './add-season-dialog.component';
+import { AuthService } from 'src/app/core/auth.service';
+import { SeasonService } from 'src/app/core/season.service';
 import { NotifyService } from 'src/app/core/notify.service';
+import { TeamsService } from 'src/app/teams/teams.service';
 
 @Component({
   selector: 'admin-page',
@@ -23,19 +25,23 @@ export class AdminPageComponent implements OnInit {
     'enabled',
     'action',
   ];
+  readonly teamColumns = ['name', 'action'];
 
   seasons$: Observable<Season[]>;
+  teams$: Observable<Team[]>;
   loading = false;
 
   constructor(
-    private dialog: MatDialog,
     public auth: AuthService,
+    private dialog: MatDialog,
+    private notifyService: NotifyService,
     private seasonService: SeasonService,
-    private notifyService: NotifyService
+    private teams: TeamsService
   ) {}
 
   ngOnInit() {
     this.seasons$ = this.seasonService.getData();
+    this.teams$ = this.teams.getTeams();
   }
 
   enable(season: Season, user: User) {
@@ -64,5 +70,15 @@ export class AdminPageComponent implements OnInit {
         });
       }
     });
+  }
+
+  addMembership(team: Team, email: string, isLead: boolean) {
+    console.log(team, email, isLead);
+    this.teams.addMembershipViaEmail(email, team, isLead).subscribe(() => {
+      this.notifyService.update(`Successfully added membership for ${email}`, 'success');
+    }, (error) => {
+      console.log(error);
+      this.notifyService.update(`Unable to add membership for ${email}`, 'error');
+    })
   }
 }

--- a/src/app/ui/admin-page/admin-page.component.ts
+++ b/src/app/ui/admin-page/admin-page.component.ts
@@ -79,6 +79,6 @@ export class AdminPageComponent implements OnInit {
     }, (error) => {
       console.log(error);
       this.notifyService.update(`Unable to add membership for ${email}`, 'error');
-    })
+    });
   }
 }

--- a/src/app/ui/ui.module.ts
+++ b/src/app/ui/ui.module.ts
@@ -5,6 +5,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import {
   MatButtonModule,
   MatCardModule,
+  MatCheckboxModule,
   MatChipsModule,
   MatDatepickerModule,
   MatDialogModule,
@@ -57,6 +58,7 @@ import { AddSeasonDialogComponent } from './admin-page/add-season-dialog.compone
     ReactiveFormsModule,
     MatButtonModule,
     MatCardModule,
+    MatCheckboxModule,
     MatChipsModule,
     MatDatepickerModule,
     MatDialogModule,


### PR DESCRIPTION
Adds a simple functionality for Admin users to add memberships.
It looks like this on the bottom of the Admin Page:
![image](https://user-images.githubusercontent.com/11013464/63312040-c0169f80-c332-11e9-8728-1c701ec1539d.png)
It will succeed as long as user email is found on the user DB, otherwise it will fail. 
Existing memberships just gets overwritten so there’s no need to worry for clicking “Add to Team” multiple times.

